### PR TITLE
Use dedicated type for positions in grid

### DIFF
--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/Cell.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/Cell.java
@@ -10,34 +10,29 @@ public class Cell implements Cloneable {
     private final CellGroup row;
     private final CellGroup column;
     private final CellGroup sector;
+    private final Position position;
     private boolean isValid;
-    private int columnIndex;
-    private int rowIndex;
     private boolean isEditable;
     private List<Integer> possibleValues;
     private int value;
     private Stack<List<Integer>> possibleValuesBackup;
     private Stack<Integer> valueBackup;
 
-    public Cell(int c, int r, CellGroup row, CellGroup column, CellGroup sector) {
+    public Cell(Position position, CellGroup row, CellGroup column, CellGroup sector) {
         this.row = row;
         this.column = column;
         this.sector = sector;
+        this.position = position;
         isEditable = true;
         isValid = true;
-        columnIndex = c;
-        rowIndex = r;
         possibleValues = new ArrayList<>();
         possibleValuesBackup = new Stack<>();
         valueBackup = new Stack<>();
     }
 
-    /**
-     * @return cell position in array. a[0] is xpos, a[1] is ypos
-     */
-    public int[] getPosition()
+    public Position getPosition()
     {
-        return new int[]{columnIndex, rowIndex};
+        return position;
     }
 
     public boolean checkIfPossibleValueListIsTheSame(List<Integer> otherList)
@@ -74,7 +69,7 @@ public class Cell implements Cloneable {
     public void setValue(int value)
     {
         if (value < 0 || value > 9)
-            throw new InvalidParameterException(String.format("Value in column: %d row: %d is not valid", columnIndex, rowIndex));
+            throw new InvalidParameterException(String.format("Value in %s is not valid", position));
         else
             this.value = value;
     }
@@ -140,12 +135,12 @@ public class Cell implements Cloneable {
         }
 
         if (possibleValues.isEmpty())
-            throw new Exception("no possible values in cell"+ columnIndex +" "+ rowIndex);
+            throw new Exception(String.format("no possible values in cell with position %s", position));
     }
 
     @Override
     public Object clone() throws CloneNotSupportedException {
-        Cell cell = new Cell(this.columnIndex, this.rowIndex,this.row,this.column,this.sector);
+        Cell cell = new Cell(this.position, this.row,this.column,this.sector);
         cell.value = this.value;
         cell.isValid = this.isValid;
         cell.possibleValues = new ArrayList<>(this.possibleValues);

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CellCollection.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CellCollection.java
@@ -55,10 +55,7 @@ public class CellCollection {
     }
 
     Cell getCellOnPosition(Position position) {
-        if (position.getRow() < GridSettings.GRID_SIZE && position.getColumn() < GridSettings.GRID_SIZE)
-            return cells[position.getRow()][position.getColumn()];
-        else
-            throw new IllegalArgumentException("out of SudokuPuzzle grid bound");
+        return cells[position.getRow()][position.getColumn()];
     }
 
     public void markAllCellsAsValid() {

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CellCollection.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CellCollection.java
@@ -24,8 +24,8 @@ public class CellCollection {
         for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
             for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
                 cells[r][c] = new Cell(
-                        c,
-                        r, rows[r], columns[c], sectors[((c / 3) * 3) + (r / 3)]);
+                        new Position(r, c),
+                        rows[r], columns[c], sectors[((c / 3) * 3) + (r / 3)]);
 
                 rows[r].addCell(cells[r][c]);
                 columns[c].addCell(cells[r][c]);
@@ -54,9 +54,9 @@ public class CellCollection {
         return cells;
     }
 
-    Cell getCellOnPosition(int r, int c) {
-        if (r < GridSettings.GRID_SIZE && c < GridSettings.GRID_SIZE)
-            return cells[r][c];
+    Cell getCellOnPosition(Position position) {
+        if (position.getRow() < GridSettings.GRID_SIZE && position.getColumn() < GridSettings.GRID_SIZE)
+            return cells[position.getRow()][position.getColumn()];
         else
             throw new IllegalArgumentException("out of SudokuPuzzle grid bound");
     }

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CoordinatesList.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CoordinatesList.java
@@ -10,20 +10,20 @@ class CoordinatesList {
         coordinates = new HashMap<>();
     }
 
-    void addCoordinate(int r, int c) {
-        String value = String.format("%d%d", r, c);
-        coordinates.putIfAbsent(value, new int[]{r, c});
+    void addCoordinate(final Position position) {
+        String value = String.format("%d%d", position.getRow(), position.getColumn());
+        coordinates.putIfAbsent(value, new int[]{position.getRow(), position.getColumn()});
     }
 
-    boolean removeCoordinate(int r, int c) {
-        String value = String.format("%d%d", r, c);
+    boolean removeCoordinate(final Position position) {
+        String value = String.format("%d%d", position.getRow(), position.getColumn());
         if (!coordinates.containsKey(value))
             return false;
         coordinates.remove(value);
         return true;
     }
 
-    boolean contains(int r, int c) {
-        return coordinates.containsKey(String.format("%d%d", r, c));
+    boolean contains(final Position position) {
+        return coordinates.containsKey(String.format("%d%d", position.getRow(), position.getColumn()));
     }
 }

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/Position.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/Position.java
@@ -41,9 +41,6 @@ public final class Position {
 
     @Override
     public String toString() {
-        return "Position{" +
-                "row=" + row +
-                ", column=" + column +
-                '}';
+        return String.format("row: %d, column: %d", row, column);
     }
 }

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/Position.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/Position.java
@@ -1,0 +1,49 @@
+package com.example.sudoku.com.example.sudoku.model;
+
+import java.util.Objects;
+
+public final class Position {
+    private final int row;
+    private final int column;
+
+    public Position(int row, int column) {
+        if (row < 0
+                || row >= GridSettings.GRID_SIZE
+                || column < 0
+                || column >= GridSettings.GRID_SIZE)
+            throw new IllegalArgumentException(
+                    String.format("Row and column must be a value between 0 and %d", GridSettings.GRID_SIZE));
+        this.row = row;
+        this.column = column;
+    }
+
+    public int getRow() {
+        return row;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Position position = (Position) o;
+        return row == position.row &&
+                column == position.column;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(row, column);
+    }
+
+    @Override
+    public String toString() {
+        return "Position{" +
+                "row=" + row +
+                ", column=" + column +
+                '}';
+    }
+}

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuPuzzle.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuPuzzle.java
@@ -42,8 +42,10 @@ public class SudokuPuzzle {
         createEmptyCells(numberOfEmptyCells);
         for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
             for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                if (collection.getCellOnPosition(r, c).getValue() == 0)
-                    emptyCells.addCoordinate(r, c);
+                final Position position = new Position(r, c);
+                if (collection.getCellOnPosition(position).getValue() == 0) {
+                    emptyCells.addCoordinate(position);
+                }
             }
         }
         return emptyCells;
@@ -63,7 +65,8 @@ public class SudokuPuzzle {
 
                 // get a cell in the first half of the grid
                 while (r == 4 && c > 4);
-                Cell cellToAdd = collection.getCellOnPosition(r, c);
+                final Position position = new Position(r, c);
+                Cell cellToAdd = collection.getCellOnPosition(position);
 
                 for (int j = 0; j < i; j++) {
                     if (emptyCells[j] == cellToAdd) {
@@ -77,9 +80,10 @@ public class SudokuPuzzle {
                     cellToAdd.getPossibleValues().clear();
 
                     // reflect the top half of the grid and make it symmetrical
-                    emptyCells[empty - i] = collection.getCellOnPosition(8 - r, 8 - c);
-                    collection.getCellOnPosition(8 - r, 8 - c).setValue(0);
-                    collection.getCellOnPosition(8 - r, 8 - c).getPossibleValues().clear();
+                    final Position reflectedPosition = new Position(8 - position.getRow(), 8 - position.getColumn());
+                    emptyCells[empty - i] = collection.getCellOnPosition(reflectedPosition);
+                    collection.getCellOnPosition(reflectedPosition).setValue(0);
+                    collection.getCellOnPosition(reflectedPosition).getPossibleValues().clear();
                 }
             }
             while (duplicate);
@@ -109,8 +113,9 @@ public class SudokuPuzzle {
 
         for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
             for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                cells_backup[r][c] = (Cell) collection.getCellOnPosition(r, c).clone();
-                collection.getCellOnPosition(r, c).ClearHistory();
+                final Position position = new Position(r, c);
+                cells_backup[r][c] = (Cell) collection.getCellOnPosition(position).clone();
+                collection.getCellOnPosition(position).ClearHistory();
             }
         }
 
@@ -155,11 +160,12 @@ public class SudokuPuzzle {
     private void reloadCells() {
         for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
             for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                if (emptyCellsCoordinates.contains(r, c)) {
-                    collection.getCellOnPosition(r, c).setValue(0);
-                    collection.getCellOnPosition(r, c).setEditable(true);
+                final Position position = new Position(r, c);
+                if (emptyCellsCoordinates.contains(position)) {
+                    collection.getCellOnPosition(position).setValue(0);
+                    collection.getCellOnPosition(position).setEditable(true);
                 } else
-                    collection.getCellOnPosition(r, c).setEditable(false);
+                    collection.getCellOnPosition(position).setEditable(false);
             }
         }
     }
@@ -172,42 +178,43 @@ public class SudokuPuzzle {
 
         for (int row = 0; row < GridSettings.GRID_SIZE; row++) {
             for (int col = 0; col < GridSettings.GRID_SIZE; col++) {
-                if (!emptyCellsCoordinates.contains(row, col)) {
-                    collection.getCellOnPosition(row, col).getPossibleValues().clear();
-                    collection.getCellOnPosition(row, col).setValue(solvedCellsBackup[row][col].getValue());
-                    collection.getCellOnPosition(row, col).getPossibleValues().add(solvedCellsBackup[row][col].getValue());
+                final Position position = new Position(row, col);
+                if (!emptyCellsCoordinates.contains(position)) {
+                    collection.getCellOnPosition(position).getPossibleValues().clear();
+                    collection.getCellOnPosition(position).setValue(solvedCellsBackup[row][col].getValue());
+                    collection.getCellOnPosition(position).getPossibleValues().add(solvedCellsBackup[row][col].getValue());
                 } else {
-                    collection.getCellOnPosition(row, col).getPossibleValues().clear();
-                    collection.getCellOnPosition(row, col).setValue(0);
+                    collection.getCellOnPosition(position).getPossibleValues().clear();
+                    collection.getCellOnPosition(position).setValue(0);
                 }
             }
         }
     }
 
     private void addRandomCoordinateToEmptyCells() {
-        int c;
-        int r;
+        Position position;
         do {
-            c = randomNumber(0, 8);
-            r = randomNumber(0, 8);
+            final int c = randomNumber(0, 8);
+            final int r = randomNumber(0, 8);
+            position = new Position(r, c);
         }
-        while (emptyCellsCoordinates.contains(r, c));
+        while (emptyCellsCoordinates.contains(position));
 
-        emptyCellsCoordinates.addCoordinate(r, c);
-        emptyCellsCoordinates.addCoordinate(8 - r, 8 - c);
+        emptyCellsCoordinates.addCoordinate(position);
+        emptyCellsCoordinates.addCoordinate(new Position(8 - position.getRow(), 8 - position.getColumn()));
     }
 
     private void removeRandomCoordinateFromEmptyCells() {
-        int c;
-        int r;
+        Position position;
         do {
-            c = randomNumber(0, 8);
-            r = randomNumber(0, 8);
+            final int c = randomNumber(0, 8);
+            final int r = randomNumber(0, 8);
+            position = new Position(r, c);
         }
-        while (!emptyCellsCoordinates.contains(r, c));
+        while (!emptyCellsCoordinates.contains(position));
 
-        emptyCellsCoordinates.removeCoordinate(r, c);
-        emptyCellsCoordinates.removeCoordinate(8 - r, 8 - c);
+        emptyCellsCoordinates.removeCoordinate(position);
+        emptyCellsCoordinates.removeCoordinate(new Position(8 - position.getRow(), 8 - position.getColumn()));
     }
 
     private boolean checkPuzzleSolution(boolean takeEmptyCellsIntoAccount) {
@@ -275,7 +282,8 @@ public class SudokuPuzzle {
     public Cell[][] resetPuzzle() {
         for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
             for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                Cell cell = collection.getCellOnPosition(r, c);
+                final Position position = new Position(r, c);
+                Cell cell = collection.getCellOnPosition(position);
                 cell = cells_backup[r][c];
                 reloadCells();
             }

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuSolver.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuSolver.java
@@ -73,7 +73,8 @@ class SudokuSolver {
     private void LoadCellsState() {
         for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
             for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-                collection.getCellOnPosition(r, c).LoadState();
+                final Position position = new Position(r, c);
+                collection.getCellOnPosition(position).LoadState();
             }
         }
     }
@@ -81,7 +82,8 @@ class SudokuSolver {
     private void SaveCellsState() {
         for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
             for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-                collection.getCellOnPosition(r, c).SaveState();
+                final Position position = new Position(r, c);
+                collection.getCellOnPosition(position).SaveState();
             }
         }
     }

--- a/app/src/main/java/com/example/sudoku/view/sudokuGrid/SudokuGridView.java
+++ b/app/src/main/java/com/example/sudoku/view/sudokuGrid/SudokuGridView.java
@@ -13,6 +13,7 @@ import android.widget.GridView;
 
 import com.example.sudoku.com.example.sudoku.model.Cell;
 import com.example.sudoku.com.example.sudoku.model.GridSettings;
+import com.example.sudoku.com.example.sudoku.model.Position;
 import com.example.sudoku.viewModel.SudokuPuzzleViewModel;
 
 import java.util.List;
@@ -176,8 +177,8 @@ public class SudokuGridView extends GridView{
 		}
 		List<Cell> invalidCells = model.getInvalidCells();
 		for (Cell cell : invalidCells) {
-			int[] position = cell.getPosition();
-			sudoku[position[1]][position[0]].setIsValid(false);
+			final Position position = cell.getPosition();
+			sudoku[position.getRow()][position.getColumn()].setIsValid(false);
 		}
 	}
 


### PR DESCRIPTION
Add and use new `Position` type to represent row-column coordinates on a Sudoku grid.
It replaces uses of two separate variables, for row and column, that represent a position on a grid.

The new type cannot be constructed with invalid coordinates (they must be in range 0..`GridSettings.GRID_SIZE`).
Because of that, checks for invalid coordinates are removed.