### PR TITLE
Add type to represent all positions in grid

### DIFF
--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/AllPositionsInGrid.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/AllPositionsInGrid.java
@@ -1,0 +1,42 @@
+package com.example.sudoku.com.example.sudoku.model;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public final class AllPositionsInGrid implements Iterable<Position> {
+    @Override
+    public Iterator<Position> iterator() {
+        return new Iterator<Position>() {
+            int currentRow = -1;
+            int currentColumn = GridSettings.GRID_SIZE - 1;
+
+            @Override
+            public boolean hasNext() {
+                return !isAtEndOfGrid();
+            }
+
+            @Override
+            public Position next() {
+                if (isAtEndOfGrid()) throw new NoSuchElementException();
+                final boolean isOnLastColumn = isOnLastColumn();
+                final int nextColumn = isOnLastColumn ? 0 : currentColumn + 1;
+                final int nextRow = isOnLastColumn ? currentRow + 1 : currentRow;
+                currentRow = nextRow;
+                currentColumn = nextColumn;
+                return new Position(nextRow, nextColumn);
+            }
+
+            private boolean isAtEndOfGrid() {
+                return isOnLastRow() && isOnLastColumn();
+            }
+
+            private boolean isOnLastRow() {
+                return currentRow == GridSettings.GRID_SIZE - 1;
+            }
+
+            private boolean isOnLastColumn() {
+                return currentColumn == GridSettings.GRID_SIZE - 1;
+            }
+        };
+    }
+}

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CellCollection.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/CellCollection.java
@@ -21,16 +21,16 @@ public class CellCollection {
             sectors[i] = new CellGroup();
         }
 
-        for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-            for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                cells[r][c] = new Cell(
-                        new Position(r, c),
-                        rows[r], columns[c], sectors[((c / 3) * 3) + (r / 3)]);
+        for (final Position position : new AllPositionsInGrid()) {
+            final int r = position.getRow();
+            final int c = position.getColumn();
+            cells[r][c] = new Cell(
+                    position,
+                    rows[r], columns[c], sectors[((c / 3) * 3) + (r / 3)]);
 
-                rows[r].addCell(cells[r][c]);
-                columns[c].addCell(cells[r][c]);
-                sectors[((c / 3) * 3) + (r / 3)].addCell(cells[r][c]);
-            }
+            rows[r].addCell(cells[r][c]);
+            columns[c].addCell(cells[r][c]);
+            sectors[((c / 3) * 3) + (r / 3)].addCell(cells[r][c]);
         }
     }
 
@@ -59,22 +59,20 @@ public class CellCollection {
     }
 
     public void markAllCellsAsValid() {
-        for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-            for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-                cells[r][c].setValid(true);
-            }
+        for (final Position position : new AllPositionsInGrid()) {
+            cells[position.getRow()][position.getColumn()].setValid(true);
         }
     }
 
     Cell findCellWithFewestPossibleValues() {
         Cell cell = null;
         int min = 10;
-        for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-            for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                if (cells[r][c].getValue() == 0 && cells[r][c].getPossibleValuesCount() < min) {
-                    min = cells[r][c].getPossibleValuesCount();
-                    cell = cells[r][c];
-                }
+        for (final Position position : new AllPositionsInGrid()) {
+            final int r = position.getRow();
+            final int c = position.getColumn();
+            if (cells[r][c].getValue() == 0 && cells[r][c].getPossibleValuesCount() < min) {
+                min = cells[r][c].getPossibleValuesCount();
+                cell = cells[r][c];
             }
         }
         return cell;

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuPuzzle.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuPuzzle.java
@@ -40,12 +40,9 @@ public class SudokuPuzzle {
         }
 
         createEmptyCells(numberOfEmptyCells);
-        for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-            for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                final Position position = new Position(r, c);
-                if (collection.getCellOnPosition(position).getValue() == 0) {
-                    emptyCells.addCoordinate(position);
-                }
+        for (final Position position : new AllPositionsInGrid()) {
+            if (collection.getCellOnPosition(position).getValue() == 0) {
+                emptyCells.addCoordinate(position);
             }
         }
         return emptyCells;
@@ -111,12 +108,10 @@ public class SudokuPuzzle {
             return false;
         }
 
-        for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-            for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                final Position position = new Position(r, c);
-                cells_backup[r][c] = (Cell) collection.getCellOnPosition(position).clone();
-                collection.getCellOnPosition(position).ClearHistory();
-            }
+        for (final Position position : new AllPositionsInGrid()) {
+            cells_backup[position.getRow()][position.getColumn()] =
+                    (Cell) collection.getCellOnPosition(position).clone();
+            collection.getCellOnPosition(position).ClearHistory();
         }
 
         emptyCellsCoordinates = initializeEmptyCells(level);
@@ -158,15 +153,12 @@ public class SudokuPuzzle {
     }
 
     private void reloadCells() {
-        for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-            for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                final Position position = new Position(r, c);
-                if (emptyCellsCoordinates.contains(position)) {
-                    collection.getCellOnPosition(position).setValue(0);
-                    collection.getCellOnPosition(position).setEditable(true);
-                } else
-                    collection.getCellOnPosition(position).setEditable(false);
-            }
+        for (final Position position : new AllPositionsInGrid()) {
+            if (emptyCellsCoordinates.contains(position)) {
+                collection.getCellOnPosition(position).setValue(0);
+                collection.getCellOnPosition(position).setEditable(true);
+            } else
+                collection.getCellOnPosition(position).setEditable(false);
         }
     }
 
@@ -176,17 +168,14 @@ public class SudokuPuzzle {
         removeRandomCoordinateFromEmptyCells();
         addRandomCoordinateToEmptyCells();
 
-        for (int row = 0; row < GridSettings.GRID_SIZE; row++) {
-            for (int col = 0; col < GridSettings.GRID_SIZE; col++) {
-                final Position position = new Position(row, col);
-                if (!emptyCellsCoordinates.contains(position)) {
-                    collection.getCellOnPosition(position).getPossibleValues().clear();
-                    collection.getCellOnPosition(position).setValue(solvedCellsBackup[row][col].getValue());
-                    collection.getCellOnPosition(position).getPossibleValues().add(solvedCellsBackup[row][col].getValue());
-                } else {
-                    collection.getCellOnPosition(position).getPossibleValues().clear();
-                    collection.getCellOnPosition(position).setValue(0);
-                }
+        for (final Position position : new AllPositionsInGrid()) {
+            if (!emptyCellsCoordinates.contains(position)) {
+                collection.getCellOnPosition(position).getPossibleValues().clear();
+                collection.getCellOnPosition(position).setValue(solvedCellsBackup[position.getRow()][position.getColumn()].getValue());
+                collection.getCellOnPosition(position).getPossibleValues().add(solvedCellsBackup[position.getRow()][position.getColumn()].getValue());
+            } else {
+                collection.getCellOnPosition(position).getPossibleValues().clear();
+                collection.getCellOnPosition(position).setValue(0);
             }
         }
     }
@@ -280,13 +269,10 @@ public class SudokuPuzzle {
     }
 
     public Cell[][] resetPuzzle() {
-        for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-            for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-                final Position position = new Position(r, c);
-                Cell cell = collection.getCellOnPosition(position);
-                cell = cells_backup[r][c];
-                reloadCells();
-            }
+        for (final Position position : new AllPositionsInGrid()) {
+            Cell cell = collection.getCellOnPosition(position);
+            cell = cells_backup[position.getRow()][position.getColumn()];
+            reloadCells();
         }
         return collection.getCells();
     }

--- a/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuSolver.java
+++ b/app/src/main/java/com/example/sudoku/com/example/sudoku/model/SudokuSolver.java
@@ -71,20 +71,14 @@ class SudokuSolver {
     }
 
     private void LoadCellsState() {
-        for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-            for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-                final Position position = new Position(r, c);
-                collection.getCellOnPosition(position).LoadState();
-            }
+        for (final Position position : new AllPositionsInGrid()) {
+            collection.getCellOnPosition(position).LoadState();
         }
     }
 
     private void SaveCellsState() {
-        for (int c = 0; c < GridSettings.GRID_SIZE; c++) {
-            for (int r = 0; r < GridSettings.GRID_SIZE; r++) {
-                final Position position = new Position(r, c);
-                collection.getCellOnPosition(position).SaveState();
-            }
+        for (final Position position : new AllPositionsInGrid()) {
+            collection.getCellOnPosition(position).SaveState();
         }
     }
 }


### PR DESCRIPTION
Add and use new type `AllPositionsInGrid` to represent all possible positions on a Sudoku grid.
It replaces the uses of two, nested `for` loops over columns and grids of the grid.